### PR TITLE
Forgot Password API routes

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -20,6 +20,10 @@ const UserSchema = new Schema({
     type: String,
     select: false
   },
+  tempPassword: {
+    type: Boolean,
+    default: false
+  },
   phoneNumber: {
     type: String
   },

--- a/routes/email-routes.js
+++ b/routes/email-routes.js
@@ -1,6 +1,7 @@
 const db = require("../models");
 const passport = require("../config/passport");
 const mongoose = require('mongoose');
+const bcrypt = require("bcryptjs");
 require('dotenv').config();
 const email = require('../config/emailConfig')
 
@@ -17,6 +18,59 @@ let transporter = nodemailer.createTransport({
 });
 
 module.exports = (app) => {
+  // FORGOT PASSWORD
+  // This one needs to receive an object from the front end { email: "user@email.com" }
+  app.post("/api/user_data/forgotpassword", function (req, res) {
+    // Take in user email, search the database for a user where that email is a match
+    db.User.findOne({ where: { email: req.body.email } })
+      .then((response) => {
+        // if no match, send back an error, otherwise, update the user's password to a random one
+        if (response === null) { res.json({ error: "No result found. Please check the e-mail address you entered." }) }
+        // Hash the random password so that it can be safely stored in the database
+        else {
+          let randomPassword = Math.floor(10000000 + Math.random() * 9000000).toString();
+          // Update the user in DB with the hashed password, and flag their account as using a temp password
+          db.User.findOneAndUpdate({ _id: mongoose.Types.ObjectId(response.id) }, 
+          {$push: { password: bcrypt.hashSync(randomPassword, bcrypt.genSaltSync(10), null), tempPassword: true } } )
+          let mailOptions = {
+            from: process.env.EMAIL_USERNAME,
+            to: response.email,
+            subject: `MERN Studios: Forgot Password`,
+            text: `Your password has been temporarily reset to: ${randomPassword}
+            If you did not request a new password, please contact us immediately.`
+          };
+          // send the e-mail to the user 
+          transporter.sendMail(mailOptions, function (error, info) {
+            // error handling
+            (error ? console.log(error) : console.log('Email sent: ' + info.response))
+          })
+        }
+      })
+      .then((response) => {
+        // Send a success message
+        res.json({ message: "success" })
+      })
+      .catch((err) => {
+        res.status(401).json(err);
+      });
+  });
+
+  // if a user logs in with a password while temp is marked ture, they will be redirected to a page to make a new password
+  // this takes in their new password from that page and updates their account
+  // needs to receive object: { email: "user@email.com", password: "newpassword" }
+  app.put("/api/user_data/changepassword", function (req, res) {
+    // hash the password, update the record, and set temp to false now. 
+    db.User.findOneAndUpdate({ email: req.body.email }, 
+      { $push: { password: bcrypt.hashSync(req.body.password, bcrypt.genSaltSync(10), null), tempPassword: false } })
+    .then((data) => {
+      // Redirect the user to the login page
+      res.json({ message: "success" })
+    })
+    .catch((err) => {
+      res.status(401).json(err);
+    });
+  })
+
   // get all students in a particular session
   app.get("/api/session/email/:sessionId", function (req, res) {
     if (!req.user) {


### PR DESCRIPTION
Here is the back end of the forgot password API.
On the front end/routing, some modification is needed: 
There needs to be a forgot password page/box somewhere (obviously). The login route also needs very simple logic added. If req.user.tempPassword = false, the user gets logged in as normal. If tempPassword=yes, they are marked as logged in BUT get directed to a page where they can choose a new password instead. From this page is where they can choose a new password and be marked as tempPassword=false. 